### PR TITLE
Added filter wrapper to stock html output generated by WooCommerce

### DIFF
--- a/index.php
+++ b/index.php
@@ -53,7 +53,7 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
 function prepare_product( $response, $post ) {
 	$product_id                   = is_callable( array( $post, 'get_id' ) ) ? $post->get_id() : ( ! empty( $post->ID ) ? $post->ID : null );
 	$product                      = wc_get_product( $product_id );
-	$response->data['stock_html'] = wc_get_stock_html( $product );
+	$response->data['stock_html'] = apply_filters( 'sixa_add_to_cart_block_product_stock_html', wc_get_stock_html( $product ), $product );
 
 	return $response;
 }
@@ -112,7 +112,7 @@ function add_attributes( $attributes, $content ) {
 
 		// Check if the stock node exists.
 		if ( $stock_node->length ) {
-			$stock_node->item( 0 )->nodeValue = wc_get_stock_html( $product );
+			$stock_node->item( 0 )->nodeValue = apply_filters( 'sixa_add_to_cart_block_product_stock_html', wc_get_stock_html( $product ), $product );
 		}
 	}
 


### PR DESCRIPTION
A filter hook has been added to further alter the output of the product stock HTML originally being generated by the WooCommerce plugin [here](http://hookr.io/functions/wc_get_stock_html/).

## Example usage:

```php
add_filter(
	'sixa_add_to_cart_block_product_stock_html',
	function( $text, $product ) {
		$text = sprintf( '<p class="stock %s">', sanitize_html_class( $product->get_stock_status() ) );
		if ( ! $product->is_in_stock() ) {
			$text .= __( 'Out of stock', '@text-domain' );
		} elseif ( $product->managing_stock() && $product->is_on_backorder( 1 ) ) {
			$text .= $product->backorders_require_notification() ? __( 'Available on backorder', '@text-domain' ) : '';
		} elseif ( ! $product->managing_stock() && $product->is_on_backorder( 1 ) ) {
			$text .= __( 'Available on backorder', '@text-domain' );
		} elseif ( $product->managing_stock() ) {
			$text .= __( 'In stock', '@text-domain' );
		} else {
			$text .= '';
		}
		$text .= '</p>';

		return $text;
	},
	10,
	2
);
```