### PR TITLE
Output anchor tag when the button text is not being entered 🐛 

### DIFF
--- a/src/save.js
+++ b/src/save.js
@@ -74,7 +74,7 @@ export default function save( { attributes } ) {
 	return (
 		<div { ...blockProps }>
 			{ displayPrice && <div className={ `${ className }__price` }></div> }
-			{ postId && ! RichText.isEmpty( text ) && (
+			{ postId && (
 				<RichText.Content
 					tagName="a"
 					value={ text }


### PR DESCRIPTION
This PR outputs anchor tag regardless of button text being entered as this HTML element could be replaced by the [Product Waitlist](https://github.com/sixach/wp-extension-product-waitlist) extension when enabled.