### PR TITLE
Declared required and supported WooCommerce version

### DIFF
--- a/index.php
+++ b/index.php
@@ -20,6 +20,8 @@
 
 namespace SixaAddToCartBlock;
 
+defined( 'ABSPATH' ) || exit; // Exit if accessed directly.
+
 /**
  * Registers the block using the metadata loaded from the `block.json` file.
  * Behind the scenes, it registers also all assets so they can be enqueued


### PR DESCRIPTION
This PR adds the WooCommerce specific plugin header fields to declare `required` and `tested up to` versions.