### PR TITLE
Missing Currency

### DIFF
--- a/block/class-add-to-cart.php
+++ b/block/class-add-to-cart.php
@@ -233,7 +233,7 @@ if ( ! class_exists( Add_To_Cart::class ) ) :
 				$return .= '</div>';
 			}
 
-			return Utils::normalize_character_entities( $return );
+			return $return;
 		}
 
 		/**


### PR DESCRIPTION
Removed call to `Utils::normalize_character_entities`. The issue is that in the price HTML, an alphanumeric currency (e.g. "CHF") is encoded with HTML numbers (e.g. `&#64;` instead of `A`). These are then caught in the `'/&[^&\s;]+;/i'` regex in `normalize_character_entities` and thus removed from the output (spacing mine):

```HTML
<div class="wp-block-sixa-add-to-cart__meta">
    <div class="wp-block-sixa-add-to-cart__price">
        <span class="woocommerce-Price-amount amount">
            <bdi>
                <span class="woocommerce-Price-currencySymbol">&#67;&#72;&#70;</span>
                <!--                                             ^    ^    ^       -->
                <!--                                             |    |    |       -->
                <!--                                       these are removed       -->
                799.00
            </bdi>
        </span>
        <small class="woocommerce-price-suffix">(inkl. MwSt.)</small>
    </div>
</div>
```

[Related task in Asana](https://app.asana.com/0/1200200504316046/1201317040874844/f)