### PR TITLE
Missing Product Check

### DIFF
--- a/block/class-add-to-cart.php
+++ b/block/class-add-to-cart.php
@@ -102,28 +102,28 @@ if ( ! class_exists( Add_To_Cart::class ) ) :
 					$product    = wc_get_product( $product_id );
 
 					if ( ! $product ) {
-						return apply_filters( 'sixa_add_to_cart_block_content', self::get_not_found_html(), $attributes );
-					}
+						$content = self::get_not_found_html();
+					} else {
+						$custom_classes  = array( 'class' => $button->getAttribute( 'class' ) );
+						$html_attributes = self::get_html_attributes( $product, $custom_classes );
+						$after_content   = apply_filters( 'sixa_add_to_cart_block_after_content', __return_empty_string(), $product, $attributes );
 
-					$custom_classes  = array( 'class' => $button->getAttribute( 'class' ) );
-					$html_attributes = self::get_html_attributes( $product, $custom_classes );
-					$after_content   = apply_filters( 'sixa_add_to_cart_block_after_content', __return_empty_string(), $product, $attributes );
-
-					if ( ! empty( $after_content ) ) {
-						$after_content_fragment = $dom->createDocumentFragment();
-						$after_content_fragment->appendXML( $after_content );
-						$button->parentNode->insertBefore( $after_content_fragment ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					}
-
-					if ( is_array( $html_attributes ) && ! empty( $html_attributes ) ) {
-						foreach ( $html_attributes as $key => $value ) {
-							$button->setAttribute( $key, $value );
+						if ( ! empty( $after_content ) ) {
+							$after_content_fragment = $dom->createDocumentFragment();
+							$after_content_fragment->appendXML( $after_content );
+							$button->parentNode->insertBefore( $after_content_fragment ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 						}
+
+						if ( is_array( $html_attributes ) && ! empty( $html_attributes ) ) {
+							foreach ( $html_attributes as $key => $value ) {
+								$button->setAttribute( $key, $value );
+							}
+						}
+
+						libxml_clear_errors();
+						$content = $dom->saveHTML();
 					}
 				}
-
-				libxml_clear_errors();
-				$content = $dom->saveHTML();
 			}
 
 			return apply_filters( 'sixa_add_to_cart_block_content', $content, $attributes );
@@ -322,13 +322,9 @@ if ( ! class_exists( Add_To_Cart::class ) ) :
 		 * @return    string
 		 */
 		public static function get_not_found_html(): string {
-			$classname = sanitize_html_class( apply_filters( 'sixa_add_to_cart_block_class_name', self::CLASSNAME ) );
-			return sprintf(
-				'<div class="%s"><p class="%s__not-found">%s</p></div>',
-				$classname,
-				$classname,
-				esc_html__( 'The selected product could not be found', 'sixa-block-add-to-cart' )
-			);
+			/* translators: 1: Open div and paragraph tags, 2: Close div and paragraph tags. */
+			$return = sprintf( esc_html__( '%1$sThe selected product could not be found.%2$s', 'sixa-block-add-to-cart' ), sprintf( '<div class="%1$s"><p class="%1$s__not-found">', sanitize_html_class( apply_filters( 'sixa_add_to_cart_block_class_name', self::CLASSNAME ) ) ), '</p></div>' );
+			return $return;
 		}
 
 		/**

--- a/src/Edit.js
+++ b/src/Edit.js
@@ -112,16 +112,6 @@ function Edit( { attributes, clientId, backgroundColor, setAttributes, setBackgr
 		() => ( { maxStockQuantity: get( product, 'stock_quantity' ), nodes: get( product, 'sixa_add_to_cart_block.nodes' ) } ),
 		[ product ]
 	);
-
-	useEffect( () => {
-		if ( ! product && ! isEditing ) {
-			toggleIsEditing();
-			if ( Boolean( postId ) ) {
-				setAttributes({ postId: undefined });
-			}
-		}
-	}, [ product ] );
-
 	const { gradientClass: backgroundGradientClass, gradientValue: backgroundGradientValue, setGradient: setBackgroundGradient } = __experimentalUseGradient();
 	const { backgroundColorClass, backgroundColorValue, textColorClass, textColorValue } = useMemo(
 		() => ( {
@@ -152,6 +142,15 @@ function Edit( { attributes, clientId, backgroundColor, setAttributes, setBackgr
 	if ( ! textColorClass ) {
 		set( styles, 'color', textColorValue );
 	}
+
+	useEffect( () => {
+		if ( ! product && ! isEditing ) {
+			toggleIsEditing();
+			if ( Boolean( postId ) ) {
+				setAttributes( { postId: undefined } );
+			}
+		}
+	}, [ product ] );
 
 	return (
 		<div { ...blockProps }>


### PR DESCRIPTION
This PR adds a check in the render callback that makes sure that the select product still exists. If the product does not exist, the block renders a "not found message".

On kettlersport.com, we are experiencing the following **Fatal Error**:
```
Fatal error: Uncaught TypeError: 
    Argument 1 passed to Sixa_Blocks\Add_To_Cart::get_html_attributes() 
    must be an object, bool given,
    called in /var/www/webroot/ROOT/wp-content/plugins/wp-block-add-to-cart/block/class-add-to-cart.php on line 109 and
    defined in /var/www/webroot/ROOT/wp-content/plugins/wp-block-add-to-cart/block/class-add-to-cart.php:344
Stack trace:
#0 /var/www/webroot/ROOT/wp-content/plugins/wp-block-add-to-cart/block/class-add-to-cart.php(109): Sixa_Blocks\Add_To_Cart::get_html_attributes()
#1 /var/www/webroot/ROOT/wp-includes/class-wp-block.php(221): Sixa_Blocks\Add_To_Cart::render()
#2 /var/www/webroot/ROOT/wp-includes/class-wp-block.php(211): WP_Block->render()
#3 /var/www/webroot/ROOT/wp-includes/blocks.php(868): WP_Block->render()
#4 /var/www/webroot/ROOT/wp-includes/blocks.php(906): render_block()
#5 /var/www/webroot/ROOT/wp-includes/class-wp-hook.php(303): do_blocks()
#6 /var/www/webroot/ROOT/wp-includes/plugin.php(189): WP_Hook->apply_filters()
#7 /var/www/webroot/ROOT/wp-includes/rest-api/endpoint in /var/www/webroot/ROOT/wp-content/plugins/wp-block-add-to-cart/block/class-add-to-cart.php on line 344
```

Additionally, this PR adds a convenience update function to keep `isEditing` and reset `postId` if no product was found.