### PR TITLE
Remove postId Removal

### DIFF
--- a/src/Edit.js
+++ b/src/Edit.js
@@ -41,7 +41,7 @@ import { Notice } from '@wordpress/components';
  *
  * @see    https://developer.wordpress.org/block-editor/reference-guides/packages/packages-element/
  */
-import { useEffect, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 
 /**
  * EventManager for JavaScript.
@@ -142,15 +142,6 @@ function Edit( { attributes, clientId, backgroundColor, setAttributes, setBackgr
 	if ( ! textColorClass ) {
 		set( styles, 'color', textColorValue );
 	}
-
-	useEffect( () => {
-		if ( ! product && ! isEditing ) {
-			toggleIsEditing();
-			if ( Boolean( postId ) ) {
-				setAttributes( { postId: undefined } );
-			}
-		}
-	}, [ product ] );
 
 	return (
 		<div { ...blockProps }>


### PR DESCRIPTION
This PR removes the convenience hook that removes the `postId` from an add-to-cart block with no `product` could be found. The hook was previously introduced in #50. On kettlersport.com we have the issue that sometimes the products cannot be fetched in the editor (reason not clear yet) even though the products do actually exist. In these instances, content-editors are unable to update the page without setting the product on every add-to-cart button again (and may forget to do so).

I am thus in favour of removing this hook as a bugfix and possibly reintroducing it in the future, perhaps with additional safety measures.